### PR TITLE
Fix ConfigMap Mount Path in Deployment Template

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
               protocol: TCP
           volumeMounts:
             - name: glance-config
-              mountPath: /app/glance.yml
+              mountPath: /app/config/glance.yml
               subPath: glance.yml
       volumes:
         - name: glance-config


### PR DESCRIPTION
The ConfigMap was being mounted at `/app/glance.yml` instead of `/app/config/glance.yml`. This update modifies `templates/deployment.yaml` to correct the mount path.