### PR TITLE
Changed the format of the config element

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "glance.labels" . | nindent 4 }}
 data:
   glance.yml: |
-    {{ .Values.config | nindent 4 }}
+    {{ toYaml .Values.config | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -33,7 +33,7 @@ ingress:
         - glance.example.com
 
 # This block is for setting up the application
-config: |
+config:
   pages:
     - name: Home
       columns:


### PR DESCRIPTION
Changed the format of the config element, from string to dict, so it's easier to edit in a browser.
The content of the config element is transformed back to a string when it is added in the glance.yml file in the configmap.
